### PR TITLE
Fix image path on line 79, made readme unzip instructions more explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ If you don't have experience in coding but still want to explore the data (blend
 ## Running heatmap locally
 
 - Download the image data from [here](https://place.thatguyalex.com/)
-  - Extract image data from the zip into the top-level directory
+  - Extract image data from the zip into the top-level directory, so that the `image_` folders are in `./final_v1/`
 
 - Install Python and the dependences listed in `requirements.txt` (by using `pip install -r requirements.txt`)
 

--- a/heatmap.ipynb
+++ b/heatmap.ipynb
@@ -76,7 +76,7 @@
     "     for file in os.listdir(folder):\n",
     "          filename = os.fsdecode(file)\n",
     "          if filename.endswith(\"png\"): \n",
-    "               img_paths.append(os.path.join(f\"{image_dir}/{folder}/\", filename))\n",
+    "               img_paths.append(os.path.join(f\"{folder}/\", filename))\n",
     "\n",
     "img_paths.sort(key = lambda x: x.split(\"/\")[-1][:-4])"
    ]


### PR DESCRIPTION
As given, line produces image path `./final_v1/./final_v1/[rest of path]` instead of `./final_v1/[rest of path]`. This change fixes it.