### PR TITLE
Adding details about Python requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ If you don't have experience in coding but still want to explore the data (blend
   - Extract image data from the zip into the top-level directory, so that the `images_` folders are in `./final_v1/`
 
 - Install Python and the dependences listed in `requirements.txt` (by using `pip install -r requirements.txt`)
+  - Python 3.9 or earlier is recommended - if you are using Python 3.10, the required version of numpy may fail to build.
 
 - Open the notebook in your IDE of choice and run
 


### PR DESCRIPTION
When attempting to set up my Python environment last night, I ran into the following error:

`error: Could not build wheels for numpy, which is required to install pyproject.toml-based project`

On Googling, it turns out that this is an issue with numpy and Python 3.10; installing Python 3.9 fixed it.

This PR is an edit to README.md that mentions the Python 3.9 requirement.

Alternatively, the issue may also be addressed by using newer versions of opencv-python and numpy, but I'm hesitant to make that change in case it breaks something.